### PR TITLE
Fix MammothModa2 decoder argument in README

### DIFF
--- a/mamoda2/README.md
+++ b/mamoda2/README.md
@@ -115,7 +115,7 @@ inputs = processor(
 with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
     generated_ids, attention_mask = model.generate(**inputs)
     decode_diffusion_image(
-        input_ids=inputs.input_ids,
+        prompt_ids=inputs.input_ids,
         generated_ids=generated_ids,
         attention_mask=attention_mask,
         negative_ids=inputs.get("negative_ids", None),

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -1,0 +1,42 @@
+import ast
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ReadmeExampleTest(unittest.TestCase):
+    def test_decode_diffusion_image_keywords_match_signature(self):
+        readme = (ROOT / "mamoda2" / "README.md").read_text(encoding="utf-8")
+        calls = []
+        for block in re.findall(r"```python\s*\n(.*?)```", readme, flags=re.DOTALL):
+            tree = ast.parse(block)
+            calls.extend(
+                node
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "decode_diffusion_image"
+            )
+
+        self.assertEqual(len(calls), 1, "expected one documented decoder call")
+        documented_keywords = {keyword.arg for keyword in calls[0].keywords if keyword.arg is not None}
+
+        source = (ROOT / "mamoda2" / "mammothmoda2" / "utils" / "t2i_utils.py").read_text(encoding="utf-8")
+        function = next(
+            node
+            for node in ast.parse(source).body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "decode_diffusion_image"
+        )
+        parameters = {
+            argument.arg for argument in (*function.args.posonlyargs, *function.args.args, *function.args.kwonlyargs)
+        }
+
+        self.assertIn("prompt_ids", documented_keywords)
+        self.assertNotIn("input_ids", documented_keywords)
+        self.assertEqual(documented_keywords - parameters, set())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- use the accepted `prompt_ids` keyword in the MammothModa2 text-to-image example
- add a regression test that parses the README example and cross-checks decoder keywords against the implementation signature

## Validation

- Python 3.11.15: `python -B -m unittest discover -s tests -v`
- `ruff check tests --config pyproject.toml`
- `ruff format --check tests --config pyproject.toml`
- README link check: 3 README files, 18 remote URLs, and 2 local targets; no failures

Fixes #28