### PR TITLE
Fix visual-token sampling scope upper bound

### DIFF
--- a/mamoda2/mammothmoda2/model/modeling_mammothmoda2.py
+++ b/mamoda2/mammothmoda2/model/modeling_mammothmoda2.py
@@ -290,7 +290,7 @@ class Mammothmoda2Model(Mammothmoda2PreTrainedModel):
     ) -> None:
         generation_config.update(**kwargs)
         scope_start = generation_config.visual_token_start_id
-        scope_end = scope_start + generation_config.visual_token_end_id
+        scope_end = generation_config.visual_token_end_id
         B, L = input_ids.shape
         cfg_enable = cfg_scale > 1.0
 

--- a/tests/test_visual_token_scope.py
+++ b/tests/test_visual_token_scope.py
@@ -1,0 +1,82 @@
+import ast
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_generate_t2i():
+    source = (ROOT / "mamoda2" / "mammothmoda2" / "model" / "modeling_mammothmoda2.py").read_text(encoding="utf-8")
+    function = next(
+        node
+        for node in ast.parse(source).body
+        if isinstance(node, ast.ClassDef)
+        for node in node.body
+        if isinstance(node, ast.FunctionDef) and node.name == "generate_t2i"
+    )
+    function.decorator_list = []
+    function.returns = None
+    for argument in (
+        *function.args.posonlyargs,
+        *function.args.args,
+        *function.args.kwonlyargs,
+    ):
+        argument.annotation = None
+    module = ast.fix_missing_locations(ast.Module(body=[function], type_ignores=[]))
+    namespace = {"LogitsProcessorList": list, "SampledScopeLogitsProcessor": ScopeRecorder}
+    exec(compile(module, str(ROOT / "modeling_mammothmoda2.py"), "exec"), namespace)
+    return namespace["generate_t2i"]
+
+
+class ScopeRecorder:
+    instances = []
+
+    def __init__(self, scope_start, scope_end):
+        self.scope_start = scope_start
+        self.scope_end = scope_end
+        self.instances.append(self)
+
+
+class GenerationConfig:
+    visual_token_start_id = 152072
+    visual_token_end_id = 168456
+    repetition_penalty = 1.0
+    temperature = 1.0
+    top_k = 0
+    top_p = 1.0
+
+    def update(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class InputIds:
+    shape = (1, 1)
+
+    def clone(self):
+        return self
+
+
+class VisualTokenScopeTest(unittest.TestCase):
+    def test_released_absolute_end_id_is_passed_to_logits_processor(self):
+        ScopeRecorder.instances.clear()
+        generate_t2i = load_generate_t2i()
+
+        generated_ids, attention_mask = generate_t2i(
+            object(),
+            input_ids=InputIds(),
+            attention_mask=object(),
+            generation_config=GenerationConfig(),
+            ar_height=0,
+            ar_width=0,
+            cfg_scale=1.0,
+        )
+
+        self.assertIsInstance(generated_ids, InputIds)
+        self.assertIsNotNone(attention_mask)
+        self.assertEqual(len(ScopeRecorder.instances), 1)
+        self.assertEqual(ScopeRecorder.instances[0].scope_start, 152072)
+        self.assertEqual(ScopeRecorder.instances[0].scope_end, 168456)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- pass the configured absolute `visual_token_end_id` directly to `SampledScopeLogitsProcessor`
- add a hermetic regression test using the released visual-token IDs

This restores the configured sampling interval `[152072, 168456)` instead of computing the out-of-vocabulary upper bound `320528`.

## Validation

- Python 3.11.15: `python -B -m unittest discover -s tests -v`
- `ruff check tests --config pyproject.toml`
- `ruff format --check tests --config pyproject.toml`

Fixes #29