### PR TITLE
Preserve CFG scales across denoising timesteps

### DIFF
--- a/mamoda2/mammothmoda2/utils/t2i_utils.py
+++ b/mamoda2/mammothmoda2/utils/t2i_utils.py
@@ -221,10 +221,11 @@ def processing(
             ref_image_hidden_states=ref_latents,
             freqs_cis=freqs_cis,
         )
-        text_guidance_scale = text_guidance_scale if cfg_range[0] <= i / len(timesteps) <= cfg_range[1] else 1.0
-        image_guidance_scale = image_guidance_scale if cfg_range[0] <= i / len(timesteps) <= cfg_range[1] else 1.0
+        in_cfg_range = cfg_range[0] <= i / len(timesteps) <= cfg_range[1]
+        step_text_guidance_scale = text_guidance_scale if in_cfg_range else 1.0
+        step_image_guidance_scale = image_guidance_scale if in_cfg_range else 1.0
 
-        if text_guidance_scale > 1.0 and image_guidance_scale > 1.0:
+        if step_text_guidance_scale > 1.0 and step_image_guidance_scale > 1.0:
             model_pred_ref = model.gen_transformer(
                 hidden_states=latents,
                 timestep=timestep,
@@ -245,11 +246,11 @@ def processing(
 
             model_pred = (
                 model_pred_uncond
-                + image_guidance_scale * (model_pred_ref - model_pred_uncond)
-                + text_guidance_scale * (model_pred - model_pred_ref)
+                + step_image_guidance_scale * (model_pred_ref - model_pred_uncond)
+                + step_text_guidance_scale * (model_pred - model_pred_ref)
             )
 
-        elif text_guidance_scale > 1.0:
+        elif step_text_guidance_scale > 1.0:
             model_pred_uncond = model.gen_transformer(
                 hidden_states=latents,
                 timestep=timestep,
@@ -259,7 +260,7 @@ def processing(
                 freqs_cis=freqs_cis,
             )
 
-            model_pred = model_pred_uncond + text_guidance_scale * (model_pred - model_pred_uncond)
+            model_pred = model_pred_uncond + step_text_guidance_scale * (model_pred - model_pred_uncond)
 
         latents = scheduler.step(model_pred, t, latents, return_dict=False)[0]
         latents = latents.to(dtype=dtype)

--- a/tests/test_cfg_range.py
+++ b/tests/test_cfg_range.py
@@ -1,0 +1,99 @@
+import ast
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_processing():
+    source = (ROOT / "mamoda2" / "mammothmoda2" / "utils" / "t2i_utils.py").read_text(encoding="utf-8")
+    function = next(
+        node for node in ast.parse(source).body if isinstance(node, ast.FunctionDef) and node.name == "processing"
+    )
+    function.decorator_list = []
+    function.returns = None
+    for argument in (
+        *function.args.posonlyargs,
+        *function.args.args,
+        *function.args.kwonlyargs,
+    ):
+        argument.annotation = None
+    module = ast.fix_missing_locations(ast.Module(body=[function], type_ignores=[]))
+    namespace = {"retrieve_timesteps": retrieve_timesteps}
+    exec(compile(module, str(ROOT / "t2i_utils.py"), "exec"), namespace)
+    return namespace["processing"]
+
+
+class FakeTensor:
+    shape = (1, 1, 2, 2)
+    dtype = "fake"
+
+    def expand(self, *shape):
+        return self
+
+    def to(self, *args, **kwargs):
+        return self
+
+
+class FakeScheduler:
+    def step(self, model_pred, timestep, latents, return_dict=False):
+        return (latents,)
+
+
+class FakeVae:
+    class Config:
+        scaling_factor = None
+        shift_factor = None
+
+    config = Config()
+
+    def decode(self, latents, return_dict=False):
+        return ("image",)
+
+
+class FakeModel:
+    def __init__(self):
+        self.transformer_calls = 0
+        self.gen_vae = FakeVae()
+
+    def gen_transformer(self, **kwargs):
+        self.transformer_calls += 1
+        return 1.0
+
+
+def retrieve_timesteps(scheduler, num_inference_steps, device, timesteps, num_tokens):
+    values = [FakeTensor() for _ in range(4)]
+    return values, len(values)
+
+
+class CfgRangeTest(unittest.TestCase):
+    def test_guidance_can_start_after_the_first_timestep(self):
+        processing = load_processing()
+        model = FakeModel()
+
+        image = processing(
+            latents=FakeTensor(),
+            ref_latents=None,
+            scheduler=FakeScheduler(),
+            model=model,
+            text_prompt_embeds=None,
+            text_prompt_attention_mask=None,
+            image_prompt_embeds=None,
+            image_prompt_attention_mask=None,
+            negative_prompt_embeds=None,
+            negative_attention_mask=None,
+            freqs_cis=None,
+            num_inference_steps=4,
+            device="cpu",
+            dtype="fake",
+            cfg_range=(0.5, 1.0),
+            text_guidance_scale=5.0,
+            image_guidance_scale=1.0,
+        )
+
+        self.assertEqual(image, "image")
+        self.assertEqual(model.transformer_calls, 6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- keep caller-provided CFG scales immutable across denoising timesteps
- derive effective text and image guidance scales for each step
- add a regression test where guidance begins after the first timestep

## Validation

- Python 3.11.15: `python -B -m unittest discover -s tests -v`
- `ruff check tests --config pyproject.toml`
- `ruff format --check tests --config pyproject.toml`

Fixes #30